### PR TITLE
Allow changing persistent data directory

### DIFF
--- a/guix-packaging.el
+++ b/guix-packaging.el
@@ -191,7 +191,7 @@
                            (buffer-file-name)))
   "Directory where guix-packaging snippets reside.")
 
-(defconst guix-packaging--data-dir
+(defvar guix-packaging--data-dir
   (concat user-emacs-directory "/var/guix-packaging/")
   "Directory for saving Guix package related data.")
 (mkdir guix-packaging--data-dir t)


### PR DESCRIPTION
The way this is written now `guix-packaging--data-dir` can't be modified before the `mkdir` immediately after it creates a directory in the user's emacs dir. Probably it should be a `defcustom` or the directory not created at the top-level but this small change would be enough.